### PR TITLE
Use ctx to enrich logging and errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,5 +18,4 @@ linters:
     - paralleltest # for now we have only one integration (not parallelable) test
     - tenv
     - varnamelen
-    - wrapcheck # nice to have
     - wsl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,11 @@ linters-settings:
     locale: US
   gosec:
     excludes: [G402]
+  ireturn:
+    allow:
+      - context.Context
+      - error
+      - io.(Reader|Writer)
 
 linters:
   enable-all: true

--- a/client.go
+++ b/client.go
@@ -7,12 +7,10 @@ import (
 
 	quic "github.com/quic-go/quic-go"
 	cli "github.com/urfave/cli/v2"
-	"golang.org/x/net/context"
 )
 
 func client(c *cli.Context) error {
-	ctx, cancel := context.WithCancel(withLabel(context.Background(), "client"))
-	defer cancel()
+	ctx := withLabel(c.Context, "client")
 
 	config := &tls.Config{
 		InsecureSkipVerify: true,

--- a/client.go
+++ b/client.go
@@ -22,22 +22,22 @@ func client(c *cli.Context) error {
 
 	udpAddr, err := net.ResolveUDPAddr("udp", c.String("addr"))
 	if err != nil {
-		return err
+		return er(err)
 	}
 	srcAddr, err := net.ResolveUDPAddr("udp", c.String("localaddr"))
 	if err != nil {
-		return err
+		return er(err)
 	}
 
 	log.Printf("Dialing %q->%q...", srcAddr.String(), udpAddr.String())
 	conn, err := net.ListenUDP("udp", srcAddr)
 	if err != nil {
-		return err
+		return er(err)
 	}
 	quicConfig := &quic.Config{MaxIdleTimeout: 10 * time.Second, KeepAlivePeriod: 5 * time.Second}
 	session, err := quic.Dial(ctx, conn, udpAddr, config, quicConfig)
 	if err != nil {
-		return err
+		return er(err)
 	}
 	defer func() {
 		if err := session.CloseWithError(0, "close"); err != nil {
@@ -48,7 +48,7 @@ func client(c *cli.Context) error {
 	log.Printf("Opening stream sync...")
 	stream, err := session.OpenStreamSync(ctx)
 	if err != nil {
-		return err
+		return er(err)
 	}
 	defer stream.Close()
 

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/tls"
-	"log"
 	"net"
 	"time"
 
@@ -12,7 +11,7 @@ import (
 )
 
 func client(c *cli.Context) error {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(withLabel(context.Background(), "client"))
 	defer cancel()
 
 	config := &tls.Config{
@@ -22,39 +21,39 @@ func client(c *cli.Context) error {
 
 	udpAddr, err := net.ResolveUDPAddr("udp", c.String("addr"))
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 	srcAddr, err := net.ResolveUDPAddr("udp", c.String("localaddr"))
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 
-	log.Printf("Dialing %q->%q...", srcAddr.String(), udpAddr.String())
+	logf(ctx, "Dialing %q->%q...", srcAddr.String(), udpAddr.String())
 	conn, err := net.ListenUDP("udp", srcAddr)
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 	quicConfig := &quic.Config{MaxIdleTimeout: 10 * time.Second, KeepAlivePeriod: 5 * time.Second}
 	session, err := quic.Dial(ctx, conn, udpAddr, config, quicConfig)
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 	defer func() {
 		if err := session.CloseWithError(0, "close"); err != nil {
-			log.Printf("session close error: %v", err)
+			logf(ctx, "session close error: %v", err)
 		}
 	}()
 
-	log.Printf("Opening stream sync...")
+	logf(ctx, "Opening stream sync...")
 	stream, err := session.OpenStreamSync(ctx)
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 	defer stream.Close()
 
-	log.Printf("Piping stream with QUIC...")
-	c1 := readAndWrite(ctx, stream, c.App.Writer) // App.Writer is stdout
-	c2 := readAndWrite(ctx, c.App.Reader, stream) // App.Reader is stdin
+	logf(ctx, "Piping stream with QUIC...")
+	c1 := readAndWrite(withLabel(ctx, "stdout"), stream, c.App.Writer) // App.Writer is stdout
+	c2 := readAndWrite(withLabel(ctx, "stdin"), c.App.Reader, stream)  // App.Reader is stdin
 	select {
 	case err = <-c1:
 	case err = <-c2:

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -11,11 +12,11 @@ import (
 	"runtime/debug"
 
 	cli "github.com/urfave/cli/v2"
-	"golang.org/x/net/context"
 )
 
 func main() {
-	ctx := context.Background() // TODO: it is application context, could be used for graceful shutdown
+	ctx, cancel := context.WithCancel(context.Background()) // TODO: application context, good for graceful shutdown
+	defer cancel()
 	build, _ := debug.ReadBuildInfo()
 	app := &cli.App{
 		Version: build.Main.Version,
@@ -39,7 +40,7 @@ func main() {
 			},
 		},
 	}
-	if err := app.Run(os.Args); err != nil {
+	if err := app.RunContext(ctx, os.Args); err != nil {
 		logf(ctx, "Error: %v", err)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -20,18 +20,18 @@ func server(c *cli.Context) error {
 	// generate TLS certificate
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return err
+		return er(err)
 	}
 	template := x509.Certificate{SerialNumber: big.NewInt(1)}
 	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
 	if err != nil {
-		return err
+		return er(err)
 	}
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
-		return err
+		return er(err)
 	}
 	config := &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
@@ -40,13 +40,13 @@ func server(c *cli.Context) error {
 
 	raddr, err := net.ResolveTCPAddr("tcp", c.String("sshdaddr"))
 	if err != nil {
-		return err
+		return er(err)
 	}
 
 	// configure listener
 	listener, err := quic.ListenAddr(c.String("bind"), config, nil)
 	if err != nil {
-		return err
+		return er(err)
 	}
 	defer listener.Close()
 	log.Printf("Listening at %q... (sshd addr: %q)", c.String("bind"), c.String("sshdaddr"))

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -12,11 +13,10 @@ import (
 
 	quic "github.com/quic-go/quic-go"
 	cli "github.com/urfave/cli/v2"
-	"golang.org/x/net/context"
 )
 
 func server(c *cli.Context) error {
-	ctx := withLabel(context.Background(), "server")
+	ctx := withLabel(c.Context, "server")
 
 	// generate TLS certificate
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/server.go
+++ b/server.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io"
-	"log"
 	"math/big"
 	"net"
 
@@ -17,21 +16,23 @@ import (
 )
 
 func server(c *cli.Context) error {
+	ctx := withLabel(context.Background(), "server")
+
 	// generate TLS certificate
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 	template := x509.Certificate{SerialNumber: big.NewInt(1)}
 	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 	config := &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
@@ -40,23 +41,22 @@ func server(c *cli.Context) error {
 
 	raddr, err := net.ResolveTCPAddr("tcp", c.String("sshdaddr"))
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 
 	// configure listener
 	listener, err := quic.ListenAddr(c.String("bind"), config, nil)
 	if err != nil {
-		return er(err)
+		return er(ctx, err)
 	}
 	defer listener.Close()
-	log.Printf("Listening at %q... (sshd addr: %q)", c.String("bind"), c.String("sshdaddr"))
+	logf(ctx, "Listening at %q... (sshd addr: %q)", c.String("bind"), c.String("sshdaddr"))
 
-	ctx := context.Background()
 	for {
-		log.Printf("Accepting connection...")
+		logf(ctx, "Accepting connection...")
 		session, err := listener.Accept(ctx)
 		if err != nil {
-			log.Printf("listener error: %v", err)
+			logf(ctx, "listener error: %v", err)
 			continue
 		}
 
@@ -65,16 +65,16 @@ func server(c *cli.Context) error {
 }
 
 func serverSessionHandler(ctx context.Context, session quic.Connection, raddr *net.TCPAddr) {
-	log.Printf("Hanling session...")
+	logf(ctx, "Hanling session...")
 	defer func() {
 		if err := session.CloseWithError(0, "close"); err != nil {
-			log.Printf("Session close error: %v", err)
+			logf(ctx, "Session close error: %v", err)
 		}
 	}()
 	for {
 		stream, err := session.AcceptStream(ctx)
 		if err != nil {
-			log.Printf("Session error: %v", err)
+			logf(ctx, "Session error: %v", err)
 			break
 		}
 		go serverStreamHandler(ctx, stream, raddr)
@@ -82,12 +82,12 @@ func serverSessionHandler(ctx context.Context, session quic.Connection, raddr *n
 }
 
 func serverStreamHandler(ctx context.Context, conn io.ReadWriteCloser, raddr *net.TCPAddr) {
-	log.Printf("Handling stream...")
+	logf(ctx, "Handling stream...")
 	defer conn.Close()
 
 	rConn, err := net.DialTCP("tcp", nil, raddr)
 	if err != nil {
-		log.Printf("Dial error: %v", err)
+		logf(ctx, "Dial error: %v", err)
 		return
 	}
 	defer rConn.Close()
@@ -95,15 +95,15 @@ func serverStreamHandler(ctx context.Context, conn io.ReadWriteCloser, raddr *ne
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	c1 := readAndWrite(ctx, conn, rConn)
-	c2 := readAndWrite(ctx, rConn, conn)
+	c1 := readAndWrite(withLabel(ctx, "toSSHD"), conn, rConn)
+	c2 := readAndWrite(withLabel(ctx, "fromSSHD"), rConn, conn)
 	select {
 	case err = <-c1:
 	case err = <-c2:
 	}
 	if err != nil {
-		log.Printf("readAndWrite error: %v", err)
+		logf(ctx, "readAndWrite error: %v", err)
 		return
 	}
-	log.Printf("Piping finished")
+	logf(ctx, "Piping finished")
 }


### PR DESCRIPTION
For example, before this changes the output of integration test looked like:

```
$ go test . -v
=== RUN   TestInegratinGoldenFlow
2025/03/29 06:44:44 Dialing ":0"->"127.0.0.1:4242"...
2025/03/29 06:44:44 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 7168 kiB, got: 416 kiB). See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.
2025/03/29 06:44:45 Listening at "localhost:4242"... (sshd addr: "localhost:8822")
2025/03/29 06:44:45 Accepting connection...
2025/03/29 06:44:45 Opening stream sync...
2025/03/29 06:44:45 Piping stream with QUIC...
2025/03/29 06:44:45 Accepting connection...
2025/03/29 06:44:45 Hanling session...
2025/03/29 06:44:45 Handling stream...
--- PASS: TestInegratinGoldenFlow (1.42s)
PASS
ok      moul.io/quicssh 1.428s
```

After this changes you can see `[client]` and `[server]` labels:

```
$ go test . -v
=== RUN   TestInegratinGoldenFlow
2025/03/29 06:45:48 [client] Dialing ":0"->"127.0.0.1:4242"...
2025/03/29 06:45:48 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 7168 kiB, got: 416 kiB). See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.
2025/03/29 06:45:48 [server] Listening at "localhost:4242"... (sshd addr: "localhost:8822")
2025/03/29 06:45:48 [server] Accepting connection...
2025/03/29 06:45:48 [client] Opening stream sync...
2025/03/29 06:45:48 [client] Piping stream with QUIC...
2025/03/29 06:45:48 [server] Accepting connection...
2025/03/29 06:45:48 [server] Hanling session...
2025/03/29 06:45:48 [server] Handling stream...
--- PASS: TestInegratinGoldenFlow (0.63s)
PASS
ok      moul.io/quicssh 0.639s
```

Errors are labeled too. This is ordinary session of client:

```
2025/03/29 06:46:54 [client] Dialing ":0"->"127.0.0.1:4242"...
2025/03/29 06:46:54 [client] Opening stream sync...
2025/03/29 06:46:54 [client] Piping stream with QUIC...
2025/03/29 06:46:55 [main] Error: [client>stdin] main.go:63: EOF
```

In last line you can see that error was logged in `[main]` function, however it appears in `clinet` code in `stdin` reading part of it.